### PR TITLE
[Fix] Mysql date 쿼리 오류 (in -> between 수정)

### DIFF
--- a/src/domain/auth/auth.controller.ts
+++ b/src/domain/auth/auth.controller.ts
@@ -43,7 +43,7 @@ export class AuthController {
 
   @Get('/mylogin') async myLogin(): Promise<JwtResponseDto> {
     return await this.authService.issueTokens({
-      id: '5660f0dc-8853-4465-ac13-9c65f2202b68',
+      id: 'dd534ccd-a023-407c-a11d-cceb09be75bc',
     } as Member);
   }
 }

--- a/src/domain/eco-verification/eco-verification.controller.ts
+++ b/src/domain/eco-verification/eco-verification.controller.ts
@@ -94,7 +94,7 @@ export class EcoVerificationController {
   @Get('my/couple')
   async getVerificationsWithYesterday(
     @Req() req: RequestMember,
-    @Query('date') date: string,
+    @Query('date') date?: string,
   ) {
     return await this.ecoVerificationService.getCoupleVerificationsWithYesterday(
       req.user.memberId,


### PR DESCRIPTION
## 수정된 부분

- date 쿼리 오류 수정


<br/><br/>

## 구현 기술의 동작 방식 및 도입 이유

### ✨Mysql 의 쿼리 중 date where 절에서 between 을 활용합니다.
> 기존 `in` 에서 `between` 으로 수정합니다.

```typescript
where: [
    {
      member: me,
      createdAt: Raw((alias) => `DATE(${alias}) IN (:...dates)`, {
        dates: [yesterdayDate, todayDate],
      }),
    },
    {
      member: lover,
      createdAt: Raw((alias) => `DATE(${alias}) IN (:...dates)`, {
        dates: [yesterdayDate, todayDate],
      }),
    },
  ],
```

```typescript
where: [
    { member: me, createdAt: Between(startOfYesterday, endOfToday) },
    { member: lover, createdAt: Between(startOfYesterday, endOfToday) },
  ],
```

#### 구현 이유
1. 기존 방식은 파라미터 바인딩이 MySQL 환경에서 제대로 동작하지 않습니다.
2. Between 으로 바꾸면 함수 호출 없이 인덱스를 타고 원하는 범위를 정확히 조회할 수 있습니다.

<br/>