### PR TITLE
[Hotfix] 인증하기 리스트에서 사전예약 인증 제거

### DIFF
--- a/src/domain/eco-verification/eco-verification.service.ts
+++ b/src/domain/eco-verification/eco-verification.service.ts
@@ -46,6 +46,9 @@ export class EcoVerificationService {
         'e.breakupBufferPoint  AS "breakupBufferPoint"',
         'e.iconImageUrl        AS "iconImageUrl"',
       ])
+      .where('e.type != :eggType', {
+        eggType: EcoVerificationType.EASTER_EGG,
+      })
       .orderBy('e.code', 'ASC')
       .getRawMany();
 


### PR DESCRIPTION
## 구현 기술의 동작 방식 및 도입 이유

### ✨ 인증하기 리스트에서 사전예약 인증 제거
> 인증하기 리스트에 사전예약 인증이 표시되는 오류

<br/>