### PR TITLE
[Feat] 개인 플레이어를 위한 솔로모드 추가

### DIFF
--- a/src/common/middleware/path-block-middleware.ts
+++ b/src/common/middleware/path-block-middleware.ts
@@ -22,6 +22,7 @@ export class PathBlockMiddleware implements NestMiddleware {
     // Couple
     { method: 'GET', path: '/api/couples/code' },
     { method: 'POST', path: '/api/couples/join' },
+    { method: 'POST', path: '/api/couples/solo' },
     { method: 'GET', path: '/api/couples/my' },
     { method: 'DELETE', path: '/api/couples/my' },
     { method: 'GET', path: /^\/api\/couples\/code\/[^/]+\/nickname$/ },

--- a/src/domain/auth/auth.controller.ts
+++ b/src/domain/auth/auth.controller.ts
@@ -43,7 +43,7 @@ export class AuthController {
 
   @Get('/mylogin') async myLogin(): Promise<JwtResponseDto> {
     return await this.authService.issueTokens({
-      id: 'm3',
+      id: 'm7',
     } as Member);
   }
 }

--- a/src/domain/couple/couple.controller.ts
+++ b/src/domain/couple/couple.controller.ts
@@ -53,6 +53,11 @@ export class CoupleController {
     );
   }
 
+  @Post('solo')
+  async joinSoloCouple(@Req() req: RequestMember): Promise<void> {
+    await this.coupleService.joinSoloCouple(req.user.memberId);
+  }
+
   @Get('my')
   async getMyCouple(@Req() req: RequestMember): Promise<CoupleDto | null> {
     return await this.coupleService.findByMemberId(req.user.memberId);

--- a/src/domain/couple/entities/couple.entity.ts
+++ b/src/domain/couple/entities/couple.entity.ts
@@ -5,6 +5,9 @@ import { CoupleItem } from './couple-item.entity';
 
 @Entity('couple')
 export class Couple extends BaseEntity {
+  @Column({ default: false })
+  isSolo: boolean;
+
   @Column({ type: 'int', unsigned: true, default: 50 })
   ecoLovePoint: number;
 

--- a/src/domain/member/entities/member.entity.ts
+++ b/src/domain/member/entities/member.entity.ts
@@ -12,6 +12,9 @@ import { MemberEcoVerification } from './member-eco-verification.entity';
 
 @Entity('member')
 export class Member extends BaseEntity {
+  @Column({ default: false })
+  isFake: boolean;
+
   @Column()
   nickname: string;
 
@@ -19,7 +22,7 @@ export class Member extends BaseEntity {
   @Column({ length: 255 })
   email: string;
 
-  @Column()
+  @Column({ nullable: true })
   profileImageUrl: string;
 
   @ManyToOne(() => Couple, (couple) => couple.members, {


### PR DESCRIPTION
## 구현 기술의 동작 방식 및 도입 이유

### ✨ 혼자서 할 수 있는 솔로모드 구현
> 혼자서도 플레이할 수 있도록 개인유저를 위한 솔로모드 구현

#### 특이사항
- member 테이블에 isFake 필드 추가
- couple 테이블에 isSolo 필드 추가
- 나중에 진짜 유저 초대하는 로직 구현 가능